### PR TITLE
add liger kernels and only compute logits over completions

### DIFF
--- a/src/training/callbacks/common.py
+++ b/src/training/callbacks/common.py
@@ -38,7 +38,6 @@ class PeriodicEvalCallback(TrainerCallback):
 def enable_gradient_checkpointing_for_lora(model) -> None:
     """
     With LoRA + gradient checkpointing, PyTorch can warn that none of the inputs require grads.
-    This mirrors the helper from `train_script.py`.
     """
     if hasattr(model, "enable_input_require_grads"):
         try:

--- a/src/training/callbacks/common.py
+++ b/src/training/callbacks/common.py
@@ -20,17 +20,36 @@ def resolve_periodic_eval_steps(trainer, *, default: int = 50) -> int:
     return max(0, int(default))
 
 
+def resolve_ipo_eval_steps() -> int:
+    """
+    IPO/CPO steps are very slow (vision + concatenated chosen/rejected forward).
+    Eval is opt-in via EVAL_STEPS; default off so training is not blocked by
+    full validation passes unless explicitly requested.
+    """
+    raw = os.environ.get("EVAL_STEPS", "").strip()
+    if raw != "":
+        return max(0, int(raw))
+    return 0
+
+
 class PeriodicEvalCallback(TrainerCallback):
     """Run evaluation every `eval_steps` (see resolve_periodic_eval_steps for how that value is chosen)."""
 
-    def __init__(self, trainer, eval_steps: int):
+    def __init__(self, trainer, eval_steps: int, *, label: str = "eval"):
         self.trainer = trainer
         self.eval_steps = int(eval_steps)
+        self.label = label
 
     def on_step_end(self, args, state, control, **kwargs):
         if self.eval_steps <= 0:
             return control
         if state.global_step > 0 and (state.global_step % self.eval_steps) == 0:
+            if (os.environ.get("LOCAL_RANK", "0")) == "0":
+                print(
+                    f"[{self.label}] starting validation at global_step={state.global_step} "
+                    f"(interval={self.eval_steps}; training progress bar will pause)",
+                    flush=True,
+                )
             self.trainer.evaluate()
         return control
 

--- a/src/training/core/config.py
+++ b/src/training/core/config.py
@@ -56,6 +56,9 @@ class RunConfig:
     use_liger: bool = False
     liger_cross_entropy: bool = False
 
+    # Data loading
+    skip_tokenized_validation: bool = False
+
     @staticmethod
     def _default_deepspeed_path() -> str | None:
         here = Path(__file__).resolve().parents[1]  # src/training
@@ -122,11 +125,21 @@ class RunConfig:
             default=_truthy_env("OCELOT_LIGER_CROSS_ENTROPY", "0"),
             help="Use Liger cross_entropy=True instead of fused linear CE (env: OCELOT_LIGER_CROSS_ENTROPY).",
         )
+        prepared_default = "1" if (os.environ.get("PREPARED_DATA_DIR") or "").strip() else "0"
+        p.add_argument(
+            "--skip-tokenized-validation",
+            action=argparse.BooleanOptionalAction,
+            default=_truthy_env("SKIP_TOKENIZED_VALIDATION", prepared_default),
+            help="Skip post-tokenization row sanity checks (env: SKIP_TOKENIZED_VALIDATION; default on for PREPARED_DATA_DIR).",
+        )
 
         ns = p.parse_args(argv)
 
         sft_max_length = int(ns.sft_max_length)
         sft_max_prompt_length = min(int(ns.sft_max_prompt_length), sft_max_length)
+        # TRL CPO/DPO require max_prompt_length < max_length (strict).
+        if sft_max_prompt_length >= sft_max_length:
+            sft_max_prompt_length = max(1, sft_max_length - 1)
 
         vision_max_pixels = None if int(ns.vision_max_pixels) <= 0 else int(ns.vision_max_pixels)
 
@@ -157,6 +170,7 @@ class RunConfig:
             qat_warmup_steps=int(ns.qat_warmup_steps),
             use_liger=bool(ns.use_liger),
             liger_cross_entropy=bool(ns.liger_cross_entropy),
+            skip_tokenized_validation=bool(ns.skip_tokenized_validation),
         )
 
 

--- a/src/training/core/config.py
+++ b/src/training/core/config.py
@@ -52,6 +52,10 @@ class RunConfig:
     qat_target_bits: int = 4
     qat_warmup_steps: int = 120
 
+    # Liger fused kernels (Qwen3-VL; CUDA only)
+    use_liger: bool = False
+    liger_cross_entropy: bool = False
+
     @staticmethod
     def _default_deepspeed_path() -> str | None:
         here = Path(__file__).resolve().parents[1]  # src/training
@@ -106,6 +110,19 @@ class RunConfig:
         p.add_argument("--qat-target-bits", type=int, default=int(os.environ.get("QAT_TARGET_BITS", "4")))
         p.add_argument("--qat-warmup-steps", type=int, default=int(os.environ.get("QAT_WARMUP_STEPS", "120")))
 
+        p.add_argument(
+            "--use-liger",
+            action=argparse.BooleanOptionalAction,
+            default=_truthy_env("OCELOT_USE_LIGER", "0"),
+            help="Patch Qwen3-VL with Liger fused kernels before load (env: OCELOT_USE_LIGER).",
+        )
+        p.add_argument(
+            "--liger-cross-entropy",
+            action=argparse.BooleanOptionalAction,
+            default=_truthy_env("OCELOT_LIGER_CROSS_ENTROPY", "0"),
+            help="Use Liger cross_entropy=True instead of fused linear CE (env: OCELOT_LIGER_CROSS_ENTROPY).",
+        )
+
         ns = p.parse_args(argv)
 
         sft_max_length = int(ns.sft_max_length)
@@ -138,6 +155,8 @@ class RunConfig:
             enable_qat=bool(ns.enable_qat),
             qat_target_bits=int(ns.qat_target_bits),
             qat_warmup_steps=int(ns.qat_warmup_steps),
+            use_liger=bool(ns.use_liger),
+            liger_cross_entropy=bool(ns.liger_cross_entropy),
         )
 
 

--- a/src/training/data/pipeline.py
+++ b/src/training/data/pipeline.py
@@ -10,7 +10,6 @@ from typing import Any
 import torch
 from datasets import Dataset, Features, Sequence, Value, concatenate_datasets, load_dataset
 from PIL import Image
-from tqdm import tqdm
 from qwen_vl_utils import process_vision_info
 
 from core.config import RunConfig
@@ -70,23 +69,27 @@ def _trim_to_batch_multiple(dataset: Dataset, batch_size: int, world_size: int =
     return dataset.select(range(new_len)), remainder
 
 
-def _example_has_image(ex: dict, *, column_names: set[str]) -> bool:
-    # Prepared-data path: image grids are present after tokenization.
-    if "image_grid_thw" in column_names:
-        g = ex.get("image_grid_thw")
-        return bool(g) and len(g) > 0
-    # Raw/preprocessed path: concrete images list.
-    if "images" in column_names:
-        imgs = ex.get("images")
-        return bool(imgs) and len(imgs) > 0
-    # Raw JSON path: inspect prompt parts for image placeholders.
-    if "prompt" in column_names:
-        for msg in ex.get("prompt") or []:
-            for part in msg.get("content") or []:
-                if isinstance(part, dict) and part.get("type") in {"image_url", "image"}:
-                    return True
-        return False
-    return False
+def _has_image_flags(dataset: Dataset) -> list[bool]:
+    """Return per-row image flags without loading heavy columns (e.g. pixel_values_bytes)."""
+    cols = set(dataset.column_names)
+    if "image_grid_thw" in cols:
+        return [bool(g) and len(g) > 0 for g in dataset["image_grid_thw"]]
+    if "images" in cols:
+        return [bool(imgs) and len(imgs) > 0 for imgs in dataset["images"]]
+    if "prompt" in cols:
+        flags: list[bool] = []
+        for prompt in dataset["prompt"]:
+            found = False
+            for msg in prompt or []:
+                for part in msg.get("content") or []:
+                    if isinstance(part, dict) and part.get("type") in {"image_url", "image"}:
+                        found = True
+                        break
+                if found:
+                    break
+            flags.append(found)
+        return flags
+    return [False] * len(dataset)
 
 
 def _drop_image_samples(dataset: Dataset, *, drop_ratio: float, seed: int) -> tuple[Dataset, int, int]:
@@ -96,14 +99,15 @@ def _drop_image_samples(dataset: Dataset, *, drop_ratio: float, seed: int) -> tu
     """
     if drop_ratio <= 0:
         return dataset, 0, 0
+    has_img = _has_image_flags(dataset)
+    if not any(has_img):
+        return dataset, 0, 0
     rng = random.Random(int(seed))
-    cols = set(dataset.column_names)
     keep_idx: list[int] = []
     image_count = 0
     dropped = 0
-    for i, ex in tqdm(enumerate(dataset)):
-        has_img = _example_has_image(ex, column_names=cols)
-        if has_img:
+    for i, hi in enumerate(has_img):
+        if hi:
             image_count += 1
             if rng.random() < float(drop_ratio):
                 dropped += 1
@@ -185,6 +189,61 @@ def _tokenized_row_is_valid(ex: dict) -> bool:
     if grid_tokens > 0:
         return False
     return True
+
+
+# Columns read by `_tokenized_row_is_valid` only (exclude heavy Parquet fields like pixel_values_bytes).
+_TOKENIZED_VALIDATION_COLUMNS = (
+    "input_ids",
+    "attention_mask",
+    "labels",
+    "mm_token_type_ids",
+    "prompt_input_ids",
+    "prompt_attention_mask",
+    "prompt_mm_token_type_ids",
+    "chosen_input_ids",
+    "chosen_attention_mask",
+    "chosen_mm_token_type_ids",
+    "rejected_input_ids",
+    "rejected_attention_mask",
+    "rejected_mm_token_type_ids",
+    "image_grid_thw",
+    "pixel_values_shape",
+    "pixel_values",
+)
+
+
+def _validation_input_columns(dataset: Dataset) -> list[str]:
+    cols = set(dataset.column_names)
+    return [c for c in _TOKENIZED_VALIDATION_COLUMNS if c in cols]
+
+
+def _filter_tokenized_valid_batch(batch: dict) -> list[bool]:
+    if not batch:
+        return []
+    n = len(next(iter(batch.values())))
+    return [
+        _tokenized_row_is_valid({col: batch[col][i] for col in batch})
+        for i in range(n)
+    ]
+
+
+def _filter_valid_tokenized_rows(dataset: Dataset, *, desc: str, skip: bool = False) -> tuple[Dataset, int]:
+    """Drop malformed tokenized rows. Returns (filtered dataset, num_dropped)."""
+    del desc  # kept for call-site clarity; no HF rewrite pass needed
+    if skip:
+        return dataset, 0
+    before = len(dataset)
+    input_cols = _validation_input_columns(dataset)
+    if not input_cols:
+        return dataset, 0
+    # Read only lightweight columns, then select indices (avoids rewriting pixel_values_bytes).
+    col_data = {c: dataset[c] for c in input_cols}
+    keep_idx = [
+        i
+        for i in range(before)
+        if _tokenized_row_is_valid({c: col_data[c][i] for c in input_cols})
+    ]
+    return dataset.select(keep_idx), before - len(keep_idx)
 
 
 def _get_chat_messages(ex: dict) -> list:
@@ -761,23 +820,19 @@ def load_and_prepare_datasets(cfg: RunConfig, *, processor: Any):
             ]
             train_cols = [c for c in torch_cols if c in dataset.column_names]
             val_cols = [c for c in torch_cols if c in val_dataset.column_names]
-            before_train = len(dataset)
-            before_val = len(val_dataset)
-            dataset = dataset.filter(
-                _tokenized_row_is_valid,
+            if rank == 0 and cfg.skip_tokenized_validation:
+                print("[data] skipping tokenized row validation", flush=True)
+            dataset, dt = _filter_valid_tokenized_rows(
+                dataset,
                 desc="Validate tokenized train rows",
-                load_from_cache_file=False,
-                writer_batch_size=1000,
+                skip=cfg.skip_tokenized_validation,
             )
-            val_dataset = val_dataset.filter(
-                _tokenized_row_is_valid,
+            val_dataset, dv = _filter_valid_tokenized_rows(
+                val_dataset,
                 desc="Validate tokenized val rows",
-                load_from_cache_file=False,
-                writer_batch_size=1000,
+                skip=cfg.skip_tokenized_validation,
             )
             if rank == 0:
-                dt = before_train - len(dataset)
-                dv = before_val - len(val_dataset)
                 print(f"[data] dropped invalid tokenized rows: train={dt}, val={dv}", flush=True)
             train_bs, eval_bs = _per_device_batch_size(), _per_device_eval_batch_size()
             dataset, train_drop = _trim_to_batch_multiple(dataset, train_bs, world_size)
@@ -935,23 +990,17 @@ def load_and_prepare_datasets(cfg: RunConfig, *, processor: Any):
         writer_batch_size=1000,
         features=_tok_features,
     )
-    before_train = len(dataset)
-    before_val = len(val_dataset)
-    dataset = dataset.filter(
-        _tokenized_row_is_valid,
+    dataset, dt = _filter_valid_tokenized_rows(
+        dataset,
         desc="Validate tokenized train rows",
-        load_from_cache_file=False,
-        writer_batch_size=1000,
+        skip=cfg.skip_tokenized_validation,
     )
-    val_dataset = val_dataset.filter(
-        _tokenized_row_is_valid,
+    val_dataset, dv = _filter_valid_tokenized_rows(
+        val_dataset,
         desc="Validate tokenized val rows",
-        load_from_cache_file=False,
-        writer_batch_size=1000,
+        skip=cfg.skip_tokenized_validation,
     )
     if rank == 0:
-        dt = before_train - len(dataset)
-        dv = before_val - len(val_dataset)
         print(f"[data] dropped invalid tokenized rows: train={dt}, val={dv}", flush=True)
     dataset = dataset.shuffle(seed=shuffle_seed)
     if rank == 0:

--- a/src/training/methods/ipo.py
+++ b/src/training/methods/ipo.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import os
 
 import torch
-from  trl.experimental.cpo import CPOConfig, CPOTrainer
+import torch.nn as nn
+from trl.experimental.cpo import CPOConfig, CPOTrainer
 
 from callbacks.common import PeriodicEvalCallback, resolve_periodic_eval_steps
 from core.config import RunConfig
@@ -11,6 +12,13 @@ from core.hf_args import build_base_training_args, _save_steps
 from data.collators import TokenizedDPOCollator
 from data.pipeline import load_and_prepare_datasets
 from methods.base import TrainingMethod
+from methods.logits_to_keep import (
+    align_logits_to_labels,
+    compute_logits_to_keep_from_labels,
+    model_supports_logits_to_keep,
+    slice_labels_for_logits_to_keep,
+    use_logits_to_keep_enabled,
+)
 from methods.sft import run_sft_stage
 from methods.trl_vision_safe import prompt_vision_tensors_from_features
 from modeling.factory import build_model_and_processor
@@ -28,6 +36,10 @@ _REQUIRED_COLS = {
 
 
 class VisionSafeCPOTrainer(CPOTrainer):
+
+    def __init__(self, *args, use_logits_to_keep: bool | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.use_logits_to_keep = use_logits_to_keep_enabled() if use_logits_to_keep is None else use_logits_to_keep
 
     def _prepare_dataset(self, dataset, processing_class, args, dataset_name):
         cols = set(getattr(dataset, "column_names", []) or [])
@@ -61,6 +73,95 @@ class VisionSafeCPOTrainer(CPOTrainer):
                 features.get("rejected_mm_token_type_ids", [0] * len(features["rejected_input_ids"])), dtype=torch.int64
             ),
         }
+
+    @staticmethod
+    def _vision_forward_kwargs(batch: dict) -> dict:
+        kwargs: dict = {}
+        pv = batch.get("prompt_pixel_values")
+        grid = batch.get("prompt_image_grid_thw")
+        if isinstance(pv, torch.Tensor) and pv.numel() > 0:
+            n = batch["chosen_input_ids"].shape[0]
+            if pv.shape[0] == n:
+                kwargs["pixel_values"] = torch.cat([pv, pv], dim=0)
+            else:
+                kwargs["pixel_values"] = pv
+        if isinstance(grid, torch.Tensor) and grid.numel() > 0:
+            n = batch["chosen_input_ids"].shape[0]
+            if grid.shape[0] == n:
+                kwargs["image_grid_thw"] = torch.cat([grid, grid], dim=0)
+            else:
+                kwargs["image_grid_thw"] = grid
+        return kwargs
+
+    def concatenated_forward(
+        self, model: nn.Module, batch: dict[str, list | torch.LongTensor]
+    ) -> tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:
+        if not self.use_logits_to_keep or not model_supports_logits_to_keep(model):
+            return super().concatenated_forward(model, batch)
+
+        concatenated_batch = self.concatenated_inputs(
+            batch,
+            is_encoder_decoder=self.is_encoder_decoder,
+            label_pad_token_id=self.label_pad_token_id,
+            padding_value=self.padding_value,
+            device=self.accelerator.device,
+        )
+        len_chosen = batch["chosen_labels"].shape[0]
+        labels = concatenated_batch["concatenated_labels"].clone()
+
+        logits_to_keep = compute_logits_to_keep_from_labels(labels, ignore_index=self.label_pad_token_id)
+        if logits_to_keep is None:
+            return super().concatenated_forward(model, batch)
+
+        model_kwargs: dict = {"use_cache": False, "logits_to_keep": logits_to_keep}
+        if self.aux_loss_enabled:
+            model_kwargs["output_router_logits"] = True
+        if self.is_encoder_decoder:
+            model_kwargs["decoder_input_ids"] = self._shift_right(labels)
+        if "concatenated_mm_token_type_ids" in concatenated_batch:
+            model_kwargs["mm_token_type_ids"] = concatenated_batch["concatenated_mm_token_type_ids"]
+        model_kwargs.update(self._vision_forward_kwargs(batch))
+
+        outputs = model(
+            concatenated_batch["concatenated_input_ids"],
+            attention_mask=concatenated_batch["concatenated_attention_mask"],
+            **model_kwargs,
+        )
+        all_logits = align_logits_to_labels(
+            outputs.logits, slice_labels_for_logits_to_keep(labels, logits_to_keep)
+        )
+        labels = slice_labels_for_logits_to_keep(labels, logits_to_keep)
+
+        def cross_entropy_loss(logits, ce_labels):
+            if not self.is_encoder_decoder:
+                logits = logits[..., :-1, :].contiguous()
+                ce_labels = ce_labels[..., 1:].contiguous()
+            loss_fct = nn.CrossEntropyLoss(ignore_index=self.label_pad_token_id)
+            flat_logits = logits.reshape(-1, logits.shape[-1])
+            flat_labels = ce_labels.reshape(-1).to(flat_logits.device)
+            return loss_fct(flat_logits, flat_labels)
+
+        if self.cpo_alpha == 0:
+            nll_loss = torch.tensor(0.0, device=self.accelerator.device)
+        else:
+            nll_loss = cross_entropy_loss(all_logits[:len_chosen], labels[:len_chosen])
+
+        all_logps = self.get_batch_logps(
+            all_logits,
+            labels,
+            average_log_prob=self.loss_type in ["ipo", "simpo"],
+            is_encoder_decoder=self.is_encoder_decoder,
+            label_pad_token_id=self.label_pad_token_id,
+        )
+
+        chosen_logps = all_logps[:len_chosen]
+        rejected_logps = all_logps[len_chosen:]
+        chosen_logits = all_logits[:len_chosen]
+        rejected_logits = all_logits[len_chosen:]
+
+        if self.aux_loss_enabled:
+            return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, nll_loss, outputs.aux_loss)
+        return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, nll_loss)
 
 
 def _build_cpo_config(cfg: RunConfig, args, processor) -> CPOConfig:

--- a/src/training/methods/ipo.py
+++ b/src/training/methods/ipo.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import contextlib
 import os
 
 import torch
 import torch.nn as nn
 from trl.experimental.cpo import CPOConfig, CPOTrainer
 
-from callbacks.common import PeriodicEvalCallback, resolve_periodic_eval_steps
+from callbacks.common import PeriodicEvalCallback, resolve_ipo_eval_steps
 from core.config import RunConfig
 from core.hf_args import build_base_training_args, _save_steps
 from data.collators import TokenizedDPOCollator
@@ -20,84 +21,270 @@ from methods.logits_to_keep import (
     use_logits_to_keep_enabled,
 )
 from methods.sft import run_sft_stage
-from methods.trl_vision_safe import prompt_vision_tensors_from_features
+from methods.trl_vision_safe import (
+    concatenated_vision_kwargs,
+    dataset_is_pretokenized,
+    drop_arrow_unsafe_vision_columns,
+    process_row_token_columns,
+)
 from modeling.factory import build_model_and_processor
 
+_SKIP_CPO_MAP_FNAMES = frozenset({"maybe_extract_prompt", "maybe_apply_chat_template", "tokenize_row"})
 
-# Same required columns as VisionSafeCPOTrainer
-_REQUIRED_COLS = {
-    "prompt_input_ids",
-    "prompt_attention_mask",
-    "chosen_input_ids",
-    "chosen_attention_mask",
-    "rejected_input_ids",
-    "rejected_attention_mask",
-}
+
+def _log_softmax_chunk_size() -> int:
+    return max(1, int(os.environ.get("IPO_LOG_SOFTMAX_CHUNK_SIZE", "64")))
+
+
+def _shift_logits_labels(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    *,
+    label_pad_token_id: int,
+    is_encoder_decoder: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if not is_encoder_decoder:
+        labels = labels[:, 1:].clone()
+        logits = logits[:, :-1, :]
+    loss_mask = labels != label_pad_token_id
+    gather_labels = labels.masked_fill(~loss_mask, 0)
+    return logits, gather_labels, loss_mask
+
+
+class _ChunkedAverageLogps(torch.autograd.Function):
+    """Average selective log-probs; backward runs softmax grad in seq chunks (memory-safe)."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        logits: torch.Tensor,
+        labels: torch.Tensor,
+        chunk_size: int,
+        label_pad_token_id: int,
+        is_encoder_decoder: bool,
+    ) -> torch.Tensor:
+        logits, gather_labels, loss_mask = _shift_logits_labels(
+            logits, labels, label_pad_token_id=label_pad_token_id, is_encoder_decoder=is_encoder_decoder
+        )
+        batch, seq_len, _ = logits.shape
+        per_token = logits.new_zeros(batch, seq_len)
+        for start in range(0, seq_len, chunk_size):
+            end = min(start + chunk_size, seq_len)
+            chunk_logits = logits[:, start:end, :]
+            chunk_labels = gather_labels[:, start:end]
+            selected = torch.gather(chunk_logits, -1, chunk_labels.unsqueeze(-1)).squeeze(-1)
+            per_token[:, start:end] = selected - torch.logsumexp(chunk_logits, dim=-1)
+        ctx.save_for_backward(logits, gather_labels, loss_mask)
+        ctx.chunk_size = chunk_size
+        ctx.is_encoder_decoder = is_encoder_decoder
+        denom = loss_mask.sum(-1).clamp(min=1)
+        return (per_token * loss_mask).sum(-1) / denom
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        logits, gather_labels, loss_mask = ctx.saved_tensors
+        chunk_size = ctx.chunk_size
+        batch, seq_len, vocab = logits.shape
+        denom = loss_mask.sum(-1, keepdim=True).clamp(min=1)
+        grad_per_token = grad_output.unsqueeze(-1) * loss_mask.float() / denom
+
+        # Single full-size gradient tensor. For decoder models the function input was
+        # one position longer (pre-shift), so allocate seq_len+1 and write the shifted
+        # region in place — avoids a second (seq x vocab) allocation + copy.
+        out_len = seq_len if ctx.is_encoder_decoder else seq_len + 1
+        grad_input = logits.new_zeros(batch, out_len, vocab)
+
+        for start in range(0, seq_len, chunk_size):
+            end = min(start + chunk_size, seq_len)
+            chunk_grad = grad_per_token[:, start:end]
+            if chunk_grad.abs().sum() == 0:
+                continue
+            chunk_logits = logits[:, start:end]
+            chunk_labels = gather_labels[:, start:end]
+            probs = torch.softmax(chunk_logits, dim=-1)
+            probs.scatter_add_(-1, chunk_labels.unsqueeze(-1), -torch.ones_like(chunk_labels, dtype=probs.dtype).unsqueeze(-1))
+            grad_input[:, start:end] = chunk_grad.unsqueeze(-1) * probs
+
+        return grad_input, None, None, None, None
+
+
+def _fused_linear_enabled() -> bool:
+    return os.environ.get("IPO_FUSED_LINEAR", "1").strip().lower() in {"1", "true", "yes"}
+
+
+def _find_lm_head_weight(model: torch.nn.Module) -> torch.Tensor | None:
+    """Locate the lm_head weight through DeepSpeed/PEFT wrappers (None if not found)."""
+    for name, mod in model.named_modules():
+        if name.endswith("lm_head") and hasattr(mod, "weight") and mod.weight is not None:
+            return mod.weight
+    get_out = getattr(model, "get_output_embeddings", None)
+    if callable(get_out):
+        try:
+            emb = get_out()
+        except Exception:
+            emb = None
+        if emb is not None and getattr(emb, "weight", None) is not None:
+            return emb.weight
+    return None
+
+
+class _FusedLinearPerTokenLogp(torch.autograd.Function):
+    """
+    Per-token log p(label) = (hidden @ Wᵀ)[label] - logsumexp(hidden @ Wᵀ), computed and
+    differentiated one sequence-chunk at a time so the full (seq × vocab) logits tensor is
+    never materialized in forward or backward.
+
+    Inputs are already shifted/aligned: hidden[:, t] predicts gather_labels[:, t].
+    Returns per-token logp of shape (rows, seq); only ``hidden`` receives gradient.
+    """
+
+    @staticmethod
+    def forward(ctx, hidden: torch.Tensor, weight: torch.Tensor, gather_labels: torch.Tensor, chunk_size: int):
+        rows, seq, _ = hidden.shape
+        out = hidden.new_zeros(rows, seq, dtype=torch.float32)
+        for start in range(0, seq, chunk_size):
+            end = min(start + chunk_size, seq)
+            chunk_logits = torch.matmul(hidden[:, start:end], weight.t()).float()
+            lse = torch.logsumexp(chunk_logits, dim=-1)
+            sel = torch.gather(chunk_logits, -1, gather_labels[:, start:end].unsqueeze(-1)).squeeze(-1)
+            out[:, start:end] = sel - lse
+        ctx.save_for_backward(hidden, weight, gather_labels)
+        ctx.chunk_size = chunk_size
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out: torch.Tensor):
+        hidden, weight, gather_labels = ctx.saved_tensors
+        chunk_size = ctx.chunk_size
+        seq = hidden.shape[1]
+        grad_hidden = torch.zeros_like(hidden)
+        wdtype = weight.dtype
+        for start in range(0, seq, chunk_size):
+            end = min(start + chunk_size, seq)
+            g = grad_out[:, start:end]
+            if g.abs().sum() == 0:
+                continue
+            chunk_logits = torch.matmul(hidden[:, start:end], weight.t()).float()
+            probs = torch.softmax(chunk_logits, dim=-1)
+            # d logp / d logits = onehot - softmax
+            probs.scatter_add_(
+                -1,
+                gather_labels[:, start:end].unsqueeze(-1),
+                -torch.ones_like(gather_labels[:, start:end], dtype=probs.dtype).unsqueeze(-1),
+            )
+            grad_logits = (-g.unsqueeze(-1)) * probs  # -(softmax - onehot) * upstream
+            grad_hidden[:, start:end] = torch.matmul(grad_logits.to(wdtype), weight)
+        return grad_hidden, None, None, None
+
+
+@contextlib.contextmanager
+def _skip_cpo_dataset_maps():
+    import datasets
+
+    orig_map = datasets.Dataset.map
+
+    def _map(self, function=None, *args, **kwargs):
+        fn = kwargs.get("function", function)
+        if getattr(fn, "__name__", None) in _SKIP_CPO_MAP_FNAMES:
+            return self
+        return orig_map(self, function, *args, **kwargs)
+
+    datasets.Dataset.map = _map
+    try:
+        yield
+    finally:
+        datasets.Dataset.map = orig_map
 
 
 class VisionSafeCPOTrainer(CPOTrainer):
 
     def __init__(self, *args, use_logits_to_keep: bool | None = None, **kwargs):
-        super().__init__(*args, **kwargs)
+        train_dataset = kwargs.get("train_dataset")
+        pretokenized = train_dataset is not None and dataset_is_pretokenized(train_dataset)
+        if pretokenized and (os.environ.get("LOCAL_RANK", "0")) == "0":
+            print(
+                "[ipo] pre-tokenized dataset: skipping CPOTrainer dataset.map "
+                "(vision loaded in collator from pixel_values_bytes)",
+                flush=True,
+            )
+        ctx = _skip_cpo_dataset_maps() if pretokenized else contextlib.nullcontext()
+        with ctx:
+            super().__init__(*args, **kwargs)
         self.use_logits_to_keep = use_logits_to_keep_enabled() if use_logits_to_keep is None else use_logits_to_keep
 
     def _prepare_dataset(self, dataset, processing_class, args, dataset_name):
-        cols = set(getattr(dataset, "column_names", []) or [])
-        if _REQUIRED_COLS.issubset(cols):
+        if dataset_is_pretokenized(dataset):
             return dataset
         return super()._prepare_dataset(dataset, processing_class, args, dataset_name)
 
     def tokenize_row(self, features, **kwargs):
         if "prompt_input_ids" in features:
-            return self.process_row(features, **kwargs)
+            return process_row_token_columns(features)
         return super().tokenize_row(features, **kwargs)
 
-    def process_row(self, features, **kwargs):
-        pv_t, grid_t = prompt_vision_tensors_from_features(features)
-        return {
-            "prompt_input_ids": torch.as_tensor(features["prompt_input_ids"], dtype=torch.int64),
-            "prompt_attention_mask": torch.as_tensor(features["prompt_attention_mask"], dtype=torch.int64),
-            "prompt_mm_token_type_ids": torch.as_tensor(
-                features.get("prompt_mm_token_type_ids", [0] * len(features["prompt_input_ids"])), dtype=torch.int64
-            ),
-            "prompt_pixel_values": pv_t,
-            "prompt_image_grid_thw": grid_t,
-            "chosen_input_ids": torch.as_tensor(features["chosen_input_ids"], dtype=torch.int64),
-            "chosen_attention_mask": torch.as_tensor(features["chosen_attention_mask"], dtype=torch.int64),
-            "chosen_mm_token_type_ids": torch.as_tensor(
-                features.get("chosen_mm_token_type_ids", [0] * len(features["chosen_input_ids"])), dtype=torch.int64
-            ),
-            "rejected_input_ids": torch.as_tensor(features["rejected_input_ids"], dtype=torch.int64),
-            "rejected_attention_mask": torch.as_tensor(features["rejected_attention_mask"], dtype=torch.int64),
-            "rejected_mm_token_type_ids": torch.as_tensor(
-                features.get("rejected_mm_token_type_ids", [0] * len(features["rejected_input_ids"])), dtype=torch.int64
-            ),
-        }
+    def get_batch_logps(
+        self,
+        logits: torch.FloatTensor,
+        labels: torch.LongTensor,
+        average_log_prob: bool = False,
+        label_pad_token_id: int = -100,
+        is_encoder_decoder: bool = False,
+    ) -> torch.FloatTensor:
+        if logits.shape[:-1] != labels.shape:
+            raise ValueError("Logits (batch and sequence length dim) and labels must have the same shape.")
 
-    @staticmethod
-    def _vision_forward_kwargs(batch: dict) -> dict:
-        kwargs: dict = {}
-        pv = batch.get("prompt_pixel_values")
-        grid = batch.get("prompt_image_grid_thw")
-        if isinstance(pv, torch.Tensor) and pv.numel() > 0:
-            n = batch["chosen_input_ids"].shape[0]
-            if pv.shape[0] == n:
-                kwargs["pixel_values"] = torch.cat([pv, pv], dim=0)
-            else:
-                kwargs["pixel_values"] = pv
-        if isinstance(grid, torch.Tensor) and grid.numel() > 0:
-            n = batch["chosen_input_ids"].shape[0]
-            if grid.shape[0] == n:
-                kwargs["image_grid_thw"] = torch.cat([grid, grid], dim=0)
-            else:
-                kwargs["image_grid_thw"] = grid
-        return kwargs
+        if average_log_prob:
+            return _ChunkedAverageLogps.apply(
+                logits,
+                labels,
+                _log_softmax_chunk_size(),
+                label_pad_token_id,
+                is_encoder_decoder,
+            )
 
-    def concatenated_forward(
-        self, model: nn.Module, batch: dict[str, list | torch.LongTensor]
-    ) -> tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor]:
-        if not self.use_logits_to_keep or not model_supports_logits_to_keep(model):
-            return super().concatenated_forward(model, batch)
+        avg = _ChunkedAverageLogps.apply(
+            logits, labels, _log_softmax_chunk_size(), label_pad_token_id, is_encoder_decoder
+        )
+        _, _, loss_mask = _shift_logits_labels(
+            logits, labels, label_pad_token_id=label_pad_token_id, is_encoder_decoder=is_encoder_decoder
+        )
+        return avg * loss_mask.sum(-1)
+
+    def _chosen_nll_loss(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        """BC regularizer on chosen (TRL-compatible); chunked CE forward, stays in autograd graph."""
+        chunk_size = _log_softmax_chunk_size()
+        if not self.is_encoder_decoder:
+            logits = logits[..., :-1, :].contiguous()
+            labels = labels[..., 1:].contiguous()
+
+        loss_fct = nn.CrossEntropyLoss(ignore_index=self.label_pad_token_id, reduction="sum")
+        total_loss = logits.new_zeros(())
+        total_valid = logits.new_zeros(())
+        for start in range(0, logits.shape[1], chunk_size):
+            end = min(start + chunk_size, logits.shape[1])
+            chunk_logits = logits[:, start:end, :]
+            chunk_labels = labels[:, start:end]
+            valid = (chunk_labels != self.label_pad_token_id).sum()
+            if int(valid.item()) == 0:
+                continue
+            chunk_ce = loss_fct(
+                chunk_logits.reshape(-1, chunk_logits.shape[-1]),
+                chunk_labels.reshape(-1),
+            )
+            total_loss = total_loss + chunk_ce
+            total_valid = total_valid + valid.float()
+        return total_loss / total_valid.clamp(min=1)
+
+    def _fused_concatenated_forward(
+        self, model: torch.nn.Module, batch: dict[str, list | torch.LongTensor]
+    ) -> tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.Tensor]:
+        """
+        One model forward for chosen+rejected; log-probs and NLL from a fused linear op so
+        the full (seq × vocab) logits tensor is never materialized (matches SFT-style memory).
+        """
+        weight = _find_lm_head_weight(model)
+        if weight is None:
+            raise RuntimeError("lm_head weight not found; cannot use fused-linear path")
 
         concatenated_batch = self.concatenated_inputs(
             batch,
@@ -107,75 +294,195 @@ class VisionSafeCPOTrainer(CPOTrainer):
             device=self.accelerator.device,
         )
         len_chosen = batch["chosen_labels"].shape[0]
-        labels = concatenated_batch["concatenated_labels"].clone()
 
-        logits_to_keep = compute_logits_to_keep_from_labels(labels, ignore_index=self.label_pad_token_id)
-        if logits_to_keep is None:
-            return super().concatenated_forward(model, batch)
-
-        model_kwargs: dict = {"use_cache": False, "logits_to_keep": logits_to_keep}
-        if self.aux_loss_enabled:
-            model_kwargs["output_router_logits"] = True
-        if self.is_encoder_decoder:
-            model_kwargs["decoder_input_ids"] = self._shift_right(labels)
+        model_kwargs: dict = {
+            "use_cache": False,
+            "output_hidden_states": True,
+            **concatenated_vision_kwargs(batch),
+        }
         if "concatenated_mm_token_type_ids" in concatenated_batch:
             model_kwargs["mm_token_type_ids"] = concatenated_batch["concatenated_mm_token_type_ids"]
-        model_kwargs.update(self._vision_forward_kwargs(batch))
+        # logits_to_keep=1 makes the model's own lm_head pass trivial; we do our own fused projection.
+        if model_supports_logits_to_keep(model):
+            model_kwargs["logits_to_keep"] = 1
+        if self.aux_loss_enabled:
+            model_kwargs["output_router_logits"] = True
 
         outputs = model(
             concatenated_batch["concatenated_input_ids"],
             attention_mask=concatenated_batch["concatenated_attention_mask"],
             **model_kwargs,
         )
-        all_logits = align_logits_to_labels(
-            outputs.logits, slice_labels_for_logits_to_keep(labels, logits_to_keep)
-        )
-        labels = slice_labels_for_logits_to_keep(labels, logits_to_keep)
+        hidden_states = getattr(outputs, "hidden_states", None)
+        if not hidden_states:
+            raise RuntimeError("model did not return hidden_states; cannot use fused-linear path")
+        hidden = hidden_states[-1]  # (rows, seq, H), grad flows back through transformer
 
-        def cross_entropy_loss(logits, ce_labels):
-            if not self.is_encoder_decoder:
-                logits = logits[..., :-1, :].contiguous()
-                ce_labels = ce_labels[..., 1:].contiguous()
-            loss_fct = nn.CrossEntropyLoss(ignore_index=self.label_pad_token_id)
-            flat_logits = logits.reshape(-1, logits.shape[-1])
-            flat_labels = ce_labels.reshape(-1).to(flat_logits.device)
-            return loss_fct(flat_logits, flat_labels)
+        labels = concatenated_batch["concatenated_labels"]
+        if hidden.shape[1] != labels.shape[1]:
+            raise RuntimeError(
+                f"hidden seq {hidden.shape[1]} != labels seq {labels.shape[1]}; cannot align fused-linear path"
+            )
+
+        # Shift: hidden[:, t] predicts labels[:, t+1].
+        shift_hidden = hidden[:, :-1, :]
+        shift_labels = labels[:, 1:]
+        loss_mask = shift_labels != self.label_pad_token_id
+        gather_labels = shift_labels.masked_fill(~loss_mask, 0)
+
+        per_token_logp = _FusedLinearPerTokenLogp.apply(
+            shift_hidden, weight, gather_labels, _log_softmax_chunk_size()
+        )  # (rows, seq-1) fp32
+
+        token_counts = loss_mask.sum(-1).clamp(min=1)
+        seq_logp_sum = (per_token_logp * loss_mask).sum(-1)
+        if self.loss_type in ["ipo", "simpo"]:
+            all_logps = seq_logp_sum / token_counts
+        else:
+            all_logps = seq_logp_sum
+
+        chosen_logps = all_logps[:len_chosen]
+        rejected_logps = all_logps[len_chosen:]
 
         if self.cpo_alpha == 0:
             nll_loss = torch.tensor(0.0, device=self.accelerator.device)
         else:
-            nll_loss = cross_entropy_loss(all_logits[:len_chosen], labels[:len_chosen])
+            # NLL = mean negative log-likelihood over chosen answer tokens (TRL BC regularizer).
+            chosen_token_logp = per_token_logp[:len_chosen]
+            chosen_mask = loss_mask[:len_chosen]
+            nll_loss = -(chosen_token_logp * chosen_mask).sum() / chosen_mask.sum().clamp(min=1)
 
-        all_logps = self.get_batch_logps(
-            all_logits,
-            labels,
+        stub = chosen_logps.new_zeros(())
+        if self.aux_loss_enabled:
+            return chosen_logps, rejected_logps, stub, stub, nll_loss, outputs.aux_loss
+        return chosen_logps, rejected_logps, stub, stub, nll_loss
+
+    def concatenated_forward(
+        self, model: torch.nn.Module, batch: dict[str, list | torch.LongTensor]
+    ) -> tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.Tensor]:
+        if _fused_linear_enabled():
+            try:
+                result = self._fused_concatenated_forward(model, batch)
+                if (os.environ.get("LOCAL_RANK", "0")) == "0" and not getattr(self, "_concat_forward_logged", False):
+                    print(
+                        "[ipo] fused-linear concatenated forward (1× pass, no full logits, "
+                        f"chunk_size={_log_softmax_chunk_size()}, cpo_alpha={self.cpo_alpha})",
+                        flush=True,
+                    )
+                    self._concat_forward_logged = True
+                return result
+            except Exception as exc:
+                if (os.environ.get("LOCAL_RANK", "0")) == "0" and not getattr(self, "_fused_fallback_logged", False):
+                    print(
+                        f"[ipo] fused-linear path unavailable ({exc}); falling back to materialized logits",
+                        flush=True,
+                    )
+                    self._fused_fallback_logged = True
+        return self._materialized_concatenated_forward(model, batch)
+
+    def _materialized_concatenated_forward(
+        self, model: torch.nn.Module, batch: dict[str, list | torch.LongTensor]
+    ) -> tuple[torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.FloatTensor, torch.Tensor]:
+        """
+        Fallback: one model forward producing full logits; chunked logps/NLL keep backward
+        memory-safe but the (seq × vocab) logits tensor is still materialized in the forward.
+        """
+        if (os.environ.get("LOCAL_RANK", "0")) == "0" and not getattr(self, "_mat_forward_logged", False):
+            print(
+                "[ipo] materialized concatenated forward (1× pass, chunked logps/NLL, "
+                f"chunk_size={_log_softmax_chunk_size()}, cpo_alpha={self.cpo_alpha})",
+                flush=True,
+            )
+            self._mat_forward_logged = True
+
+        concatenated_batch = self.concatenated_inputs(
+            batch,
+            is_encoder_decoder=self.is_encoder_decoder,
+            label_pad_token_id=self.label_pad_token_id,
+            padding_value=self.padding_value,
+            device=self.accelerator.device,
+        )
+        len_chosen = batch["chosen_labels"].shape[0]
+
+        model_kwargs: dict = {
+            "use_cache": False,
+            **concatenated_vision_kwargs(batch),
+        }
+        if "concatenated_mm_token_type_ids" in concatenated_batch:
+            model_kwargs["mm_token_type_ids"] = concatenated_batch["concatenated_mm_token_type_ids"]
+
+        labels = concatenated_batch["concatenated_labels"]
+        logits_to_keep = None
+        if self.use_logits_to_keep and model_supports_logits_to_keep(model):
+            logits_to_keep = compute_logits_to_keep_from_labels(
+                labels, ignore_index=self.label_pad_token_id
+            )
+            if logits_to_keep is not None:
+                model_kwargs["logits_to_keep"] = logits_to_keep
+
+        if self.aux_loss_enabled:
+            model_kwargs["output_router_logits"] = True
+
+        outputs = model(
+            concatenated_batch["concatenated_input_ids"],
+            attention_mask=concatenated_batch["concatenated_attention_mask"],
+            **model_kwargs,
+        )
+        all_logits = outputs.logits
+        if self.aux_loss_enabled:
+            aux_loss = outputs.aux_loss
+
+        if logits_to_keep is not None:
+            labels_kept = slice_labels_for_logits_to_keep(labels, logits_to_keep)
+            all_logits = align_logits_to_labels(all_logits, labels_kept)
+            labels = labels_kept
+
+        chosen_logits = all_logits[:len_chosen]
+        rejected_logits = all_logits[len_chosen:]
+        chosen_labels = labels[:len_chosen]
+        rejected_labels = labels[len_chosen:]
+
+        if self.cpo_alpha == 0:
+            nll_loss = torch.tensor(0.0, device=self.accelerator.device)
+        else:
+            nll_loss = self._chosen_nll_loss(chosen_logits, chosen_labels)
+
+        chosen_logps = self.get_batch_logps(
+            chosen_logits,
+            chosen_labels,
+            average_log_prob=self.loss_type in ["ipo", "simpo"],
+            is_encoder_decoder=self.is_encoder_decoder,
+            label_pad_token_id=self.label_pad_token_id,
+        )
+        rejected_logps = self.get_batch_logps(
+            rejected_logits,
+            rejected_labels,
             average_log_prob=self.loss_type in ["ipo", "simpo"],
             is_encoder_decoder=self.is_encoder_decoder,
             label_pad_token_id=self.label_pad_token_id,
         )
 
-        chosen_logps = all_logps[:len_chosen]
-        rejected_logps = all_logps[len_chosen:]
-        chosen_logits = all_logits[:len_chosen]
-        rejected_logits = all_logits[len_chosen:]
-
+        stub = chosen_logps.new_zeros(())
         if self.aux_loss_enabled:
-            return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, nll_loss, outputs.aux_loss)
-        return (chosen_logps, rejected_logps, chosen_logits, rejected_logits, nll_loss)
+            return chosen_logps, rejected_logps, stub, stub, nll_loss, aux_loss
+        return chosen_logps, rejected_logps, stub, stub, nll_loss
 
 
 def _build_cpo_config(cfg: RunConfig, args, processor) -> CPOConfig:
     """Build CPOConfig: base args + IPO params, with fallbacks for TRL API changes."""
     save_steps = _save_steps()
+    cpo_alpha = float(os.environ.get("IPO_CPO_ALPHA", "5"))
     try:
         cpo_config = CPOConfig(
             **args.to_dict(),
             loss_type="ipo",
             padding_value=processor.tokenizer.pad_token_id,
-            cpo_alpha=5,
+            cpo_alpha=cpo_alpha,
         )
     except TypeError:
         cpo_config = CPOConfig(**args.to_dict(), loss_type="ipo")
+    if hasattr(cpo_config, "cpo_alpha"):
+        setattr(cpo_config, "cpo_alpha", cpo_alpha)
     if hasattr(cpo_config, "beta"):
         setattr(cpo_config, "beta", float(cfg.ipo_beta))
     if hasattr(cpo_config, "loss_type"):
@@ -195,6 +502,8 @@ class IPOMethod(TrainingMethod):
     def run(self, cfg: RunConfig) -> None:
         bundle = build_model_and_processor(cfg)
         train_ds, val_ds = load_and_prepare_datasets(cfg, processor=bundle.processor)
+        train_ds = drop_arrow_unsafe_vision_columns(train_ds)
+        val_ds = drop_arrow_unsafe_vision_columns(val_ds)
 
         if int(cfg.sft_warmup_epochs) > 0:
             run_sft_stage(
@@ -216,8 +525,17 @@ class IPOMethod(TrainingMethod):
             epochs=cfg.epochs,
             learning_rate=float(cfg.pref_learning_rate),
         )
+        # Preference training is slow; avoid HF's built-in step eval (PeriodicEvalCallback is opt-in).
+        args.eval_strategy = "no"
 
         cpo_config = _build_cpo_config(cfg, args, bundle.processor)
+        if (os.environ.get("LOCAL_RANK", "0")) == "0":
+            print(
+                f"[ipo] loss_type=ipo beta={getattr(cpo_config, 'beta', None)} "
+                f"(IPO_BETA / --ipo-beta) cpo_alpha={getattr(cpo_config, 'cpo_alpha', None)} "
+                f"(IPO_CPO_ALPHA env, BC regularizer weight)",
+                flush=True,
+            )
 
         trainer = VisionSafeCPOTrainer(
             model=bundle.model,
@@ -228,6 +546,12 @@ class IPOMethod(TrainingMethod):
             data_collator=collator,
             callbacks=list(bundle.callbacks),
         )
-        trainer.add_callback(PeriodicEvalCallback(trainer, eval_steps=resolve_periodic_eval_steps(trainer)))
+        ipo_eval_steps = resolve_ipo_eval_steps()
+        if ipo_eval_steps > 0:
+            if (os.environ.get("LOCAL_RANK", "0")) == "0":
+                print(f"[ipo] periodic validation enabled (EVAL_STEPS={ipo_eval_steps})", flush=True)
+            trainer.add_callback(PeriodicEvalCallback(trainer, eval_steps=ipo_eval_steps, label="ipo"))
+        elif (os.environ.get("LOCAL_RANK", "0")) == "0":
+            print("[ipo] validation disabled during training (set EVAL_STEPS>0 to enable)", flush=True)
         trainer.train()
         bundle.model.save_pretrained(os.path.join(cfg.output_dir, "adapter-ocelot"))

--- a/src/training/methods/logits_to_keep.py
+++ b/src/training/methods/logits_to_keep.py
@@ -10,11 +10,36 @@ def use_logits_to_keep_enabled() -> bool:
     return os.environ.get("USE_LOGITS_TO_KEEP", "1").strip().lower() in {"1", "true", "yes"}
 
 
-def model_supports_logits_to_keep(model) -> bool:
-    """Return True if `model.forward` accepts `logits_to_keep`."""
-    for candidate in (model, getattr(model, "base_model", None), getattr(model, "model", None)):
+def _model_candidates(model) -> list:
+    """Walk DeepSpeed / DDP / PEFT wrappers to find modules that may support logits_to_keep."""
+    candidates: list = []
+    seen: set[int] = set()
+    queue = [model]
+    while queue:
+        candidate = queue.pop(0)
         if candidate is None:
             continue
+        cid = id(candidate)
+        if cid in seen:
+            continue
+        seen.add(cid)
+        candidates.append(candidate)
+        get_base = getattr(candidate, "get_base_model", None)
+        if callable(get_base):
+            try:
+                queue.append(get_base())
+            except Exception:
+                pass
+        for attr in ("module", "base_model", "model"):
+            child = getattr(candidate, attr, None)
+            if child is not None and id(child) not in seen:
+                queue.append(child)
+    return candidates
+
+
+def model_supports_logits_to_keep(model) -> bool:
+    """Return True if `model.forward` accepts `logits_to_keep`."""
+    for candidate in _model_candidates(model):
         fn = getattr(candidate, "_supports_logits_to_keep", None)
         if callable(fn) and fn():
             return True

--- a/src/training/methods/logits_to_keep.py
+++ b/src/training/methods/logits_to_keep.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import inspect
+import os
+
+import torch
+
+
+def use_logits_to_keep_enabled() -> bool:
+    return os.environ.get("USE_LOGITS_TO_KEEP", "1").strip().lower() in {"1", "true", "yes"}
+
+
+def model_supports_logits_to_keep(model) -> bool:
+    """Return True if `model.forward` accepts `logits_to_keep`."""
+    for candidate in (model, getattr(model, "base_model", None), getattr(model, "model", None)):
+        if candidate is None:
+            continue
+        fn = getattr(candidate, "_supports_logits_to_keep", None)
+        if callable(fn) and fn():
+            return True
+        forward = getattr(candidate, "forward", None)
+        if forward is not None and "logits_to_keep" in inspect.signature(forward).parameters:
+            return True
+    return False
+
+
+def compute_logits_to_keep_from_labels(labels: torch.Tensor, *, ignore_index: int = -100) -> int | None:
+    """
+    Compute how many trailing positions need lm_head logits.
+
+    Uses the earliest supervised label in the batch (conservative for mixed-length completions).
+    """
+    loss_mask = labels != ignore_index
+    if not loss_mask.any():
+        return None
+    first_idx = loss_mask.nonzero(as_tuple=True)[1].min()
+    return int((labels.shape[1] - first_idx).item() + 1)
+
+
+def slice_labels_for_logits_to_keep(labels: torch.Tensor, logits_to_keep: int) -> torch.Tensor:
+    return labels[:, -logits_to_keep:].contiguous()
+
+
+def align_logits_to_labels(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    """Align logits length to labels (Qwen-VL may prepend image-token logits)."""
+    if logits.shape[:2] == labels.shape[:2]:
+        return logits
+    return logits[:, -labels.shape[1] :]

--- a/src/training/methods/sft.py
+++ b/src/training/methods/sft.py
@@ -12,13 +12,59 @@ from core.hf_args import build_sft_training_args
 from data.collators import TokenizedSFTCollator
 from data.pipeline import load_and_prepare_datasets
 from methods.base import TrainingMethod
+from methods.logits_to_keep import (
+    compute_logits_to_keep_from_labels,
+    model_supports_logits_to_keep,
+    slice_labels_for_logits_to_keep,
+    use_logits_to_keep_enabled,
+)
 from modeling.factory import build_model_and_processor
+from modeling.liger_kernels import liger_fused_ce_active
 
 
 class VisionSFTTrainer(Trainer):
     """
     Plain HF Trainer for SFT, with a vision-safe collator + DeepSpeed-safe scalar loss.
     """
+
+    def __init__(self, *args, cfg: RunConfig | None = None, use_logits_to_keep: bool | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        want_keep = use_logits_to_keep_enabled() if use_logits_to_keep is None else use_logits_to_keep
+        if want_keep and liger_fused_ce_active(cfg):
+            if os.environ.get("LOCAL_RANK", "0") == "0":
+                print(
+                    "[sft] USE_LOGITS_TO_KEEP disabled: Liger fused linear CE is active "
+                    "(redundant and incompatible with logits_to_keep slicing)",
+                    flush=True,
+                )
+            want_keep = False
+        self.use_logits_to_keep = want_keep
+
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
+        if not self.use_logits_to_keep:
+            return super().compute_loss(
+                model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
+            )
+
+        labels = inputs.get("labels")
+        if labels is None or not model_supports_logits_to_keep(model):
+            return super().compute_loss(
+                model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
+            )
+
+        logits_to_keep = compute_logits_to_keep_from_labels(labels, ignore_index=-100)
+        if logits_to_keep is None:
+            return super().compute_loss(
+                model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
+            )
+
+        model_inputs = dict(inputs)
+        model_inputs["labels"] = slice_labels_for_logits_to_keep(labels, logits_to_keep)
+        model_inputs["logits_to_keep"] = logits_to_keep
+        model_inputs["use_cache"] = False
+        return super().compute_loss(
+            model, model_inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
+        )
 
     def training_step(self, model, inputs, num_items_in_batch=None):
         model.train()
@@ -61,6 +107,7 @@ def run_sft_stage(
         data_collator=collator,
         processing_class=processor.tokenizer,
         callbacks=list(callbacks),
+        cfg=cfg,
     )
     trainer.add_callback(PeriodicEvalCallback(trainer, eval_steps=resolve_periodic_eval_steps(trainer)))
     if getattr(args, "gradient_checkpointing", False):

--- a/src/training/methods/sft.py
+++ b/src/training/methods/sft.py
@@ -19,7 +19,7 @@ from methods.logits_to_keep import (
     use_logits_to_keep_enabled,
 )
 from modeling.factory import build_model_and_processor
-from modeling.liger_kernels import liger_fused_ce_active
+from modeling.liger_kernels import liger_fused_ce_active, use_liger_active
 
 
 class VisionSFTTrainer(Trainer):
@@ -29,6 +29,8 @@ class VisionSFTTrainer(Trainer):
 
     def __init__(self, *args, cfg: RunConfig | None = None, use_logits_to_keep: bool | None = None, **kwargs):
         super().__init__(*args, **kwargs)
+        self._cfg = cfg
+        self._use_liger = use_liger_active(cfg)
         want_keep = use_logits_to_keep_enabled() if use_logits_to_keep is None else use_logits_to_keep
         if want_keep and liger_fused_ce_active(cfg):
             if os.environ.get("LOCAL_RANK", "0") == "0":
@@ -39,21 +41,57 @@ class VisionSFTTrainer(Trainer):
                 )
             want_keep = False
         self.use_logits_to_keep = want_keep
+        self._use_liger_fused_ce = liger_fused_ce_active(cfg)
+        if os.environ.get("LOCAL_RANK", "0") == "0":
+            if self._use_liger_fused_ce:
+                print("[sft] loss path: Liger fused linear CE (skip_logits)", flush=True)
+            elif self._use_liger:
+                print(
+                    "[sft] loss path: logits_to_keep "
+                    "(OCELOT_LIGER_CROSS_ENTROPY=1 does not support skip_logits; unset it to use fused CE)",
+                    flush=True,
+                )
+            elif self.use_logits_to_keep:
+                print("[sft] loss path: logits_to_keep", flush=True)
+            else:
+                print("[sft] loss path: full logits (high memory)", flush=True)
 
-    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
-        if not self.use_logits_to_keep:
-            return super().compute_loss(
-                model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
-            )
+    def _compute_loss_with_liger(self, model, inputs, *, return_outputs: bool, num_items_in_batch=None):
+        """
+        Liger's patched forward only sets skip_logits=True in training mode; eval materializes full
+        logits and OOMs on long context. Force skip_logits so eval uses the fused loss path too.
+        """
+        model_inputs = dict(inputs)
+        model_inputs["skip_logits"] = True
+        loss = super().compute_loss(
+            model, model_inputs, return_outputs=False, num_items_in_batch=num_items_in_batch
+        )
+        if return_outputs:
+            return loss, None
+        return loss
 
+    def _warn_full_logits_once(self, reason: str) -> None:
+        if getattr(self, "_full_logits_warned", False):
+            return
+        self._full_logits_warned = True
+        if os.environ.get("LOCAL_RANK", "0") == "0":
+            print(f"[sft] WARNING: falling back to full-vocab logits ({reason})", flush=True)
+
+    def _compute_loss_with_logits_to_keep(self, model, inputs, *, return_outputs: bool, num_items_in_batch=None):
         labels = inputs.get("labels")
         if labels is None or not model_supports_logits_to_keep(model):
+            self._warn_full_logits_once(
+                "model does not support logits_to_keep"
+                if labels is not None
+                else "batch has no labels"
+            )
             return super().compute_loss(
                 model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
             )
 
         logits_to_keep = compute_logits_to_keep_from_labels(labels, ignore_index=-100)
         if logits_to_keep is None:
+            self._warn_full_logits_once("no supervised labels in batch")
             return super().compute_loss(
                 model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
             )
@@ -65,6 +103,27 @@ class VisionSFTTrainer(Trainer):
         return super().compute_loss(
             model, model_inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
         )
+
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
+        if self._use_liger_fused_ce:
+            return self._compute_loss_with_liger(
+                model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
+            )
+
+        if self.use_logits_to_keep:
+            return self._compute_loss_with_logits_to_keep(
+                model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
+            )
+
+        self._warn_full_logits_once("USE_LOGITS_TO_KEEP=0")
+        return super().compute_loss(
+            model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
+        )
+
+    def prediction_step(self, model, inputs, prediction_loss_only, ignore_keys=None):
+        if self._use_liger_fused_ce:
+            prediction_loss_only = True
+        return super().prediction_step(model, inputs, prediction_loss_only, ignore_keys=ignore_keys)
 
     def training_step(self, model, inputs, num_items_in_batch=None):
         model.train()

--- a/src/training/methods/trl_vision_safe.py
+++ b/src/training/methods/trl_vision_safe.py
@@ -68,19 +68,16 @@ REQUIRED_TOKEN_COLS = {
 }
 
 
-def process_row_with_vision(features: dict) -> dict:
+def process_row_token_columns(features: dict) -> dict:
     """
-    Convert pre-tokenized dataset rows into the structure TRL expects, including optional vision columns.
+    Token columns only for TRL map() — vision is attached in the collator (avoids Arrow 2GB overflow).
     """
-    pv_t, grid_t = prompt_vision_tensors_from_features(features)
     return {
         "prompt_input_ids": torch.as_tensor(features["prompt_input_ids"], dtype=torch.int64),
         "prompt_attention_mask": torch.as_tensor(features["prompt_attention_mask"], dtype=torch.int64),
         "prompt_mm_token_type_ids": torch.as_tensor(
             features.get("prompt_mm_token_type_ids", [0] * len(features["prompt_input_ids"])), dtype=torch.int64
         ),
-        "prompt_pixel_values": pv_t,
-        "prompt_image_grid_thw": grid_t,
         "chosen_input_ids": torch.as_tensor(features["chosen_input_ids"], dtype=torch.int64),
         "chosen_attention_mask": torch.as_tensor(features["chosen_attention_mask"], dtype=torch.int64),
         "chosen_mm_token_type_ids": torch.as_tensor(
@@ -92,4 +89,52 @@ def process_row_with_vision(features: dict) -> dict:
             features.get("rejected_mm_token_type_ids", [0] * len(features["rejected_input_ids"])), dtype=torch.int64
         ),
     }
+
+
+def process_row_with_vision(features: dict) -> dict:
+    """
+    Convert pre-tokenized dataset rows into the structure TRL expects, including optional vision columns.
+    """
+    out = process_row_token_columns(features)
+    pv_t, grid_t = prompt_vision_tensors_from_features(features)
+    out["prompt_pixel_values"] = pv_t
+    out["prompt_image_grid_thw"] = grid_t
+    return out
+
+
+def dataset_is_pretokenized(dataset) -> bool:
+    cols = set(getattr(dataset, "column_names", []) or [])
+    return REQUIRED_TOKEN_COLS.issubset(cols)
+
+
+def dup_vision_for_concatenated(t: torch.Tensor) -> torch.Tensor:
+    """
+    Duplicate vision tensors for IPO/CPO concatenated forward ([chosen…, rejected…]).
+
+    The collator stacks patches as flat (total_patches, D) and image_grid_thw as (num_images, 3).
+    Doubling the full block yields [ex0 imgs, ex1 imgs, …, ex0 imgs, ex1 imgs, …], which matches
+    how Qwen-VL maps images onto concatenated text rows.
+
+    Never skip duplication when image_grid_thw.shape[0] == 2 * batch_size — that also occurs when
+    one example has two images (batch_size=1), which still must be doubled for chosen+rejected.
+    """
+    return torch.cat([t, t], dim=0)
+
+
+def concatenated_vision_kwargs(batch: dict) -> dict:
+    """Build model kwargs with pixel_values / image_grid_thw duplicated for concatenated forward."""
+    kwargs: dict = {}
+    pv = batch.get("prompt_pixel_values")
+    grid = batch.get("prompt_image_grid_thw")
+    if isinstance(pv, torch.Tensor) and pv.numel() > 0:
+        kwargs["pixel_values"] = dup_vision_for_concatenated(pv)
+    if isinstance(grid, torch.Tensor) and grid.numel() > 0:
+        kwargs["image_grid_thw"] = dup_vision_for_concatenated(grid)
+    return kwargs
+
+
+def drop_arrow_unsafe_vision_columns(dataset):
+    """Remove nested-list vision columns; collator uses pixel_values_bytes from Parquet."""
+    drop = [c for c in ("pixel_values", "prompt_pixel_values") if c in getattr(dataset, "column_names", [])]
+    return dataset.remove_columns(drop) if drop else dataset
 

--- a/src/training/modeling/factory.py
+++ b/src/training/modeling/factory.py
@@ -11,6 +11,7 @@ from callbacks.qat import QATCallback, StableSimulatedQuant, apply_noise_to_base
 from core.config import RunConfig
 from core.torch_patches import patch_torch_linspace_steps
 from data.vision import configure_qwen_processor_image_limits
+from modeling.liger_kernels import maybe_apply_liger_kernel
 
 
 @dataclass(frozen=True)
@@ -30,6 +31,8 @@ def build_model_and_processor(cfg: RunConfig) -> ModelBundle:
     configure_qwen_processor_image_limits(processor, vision_max_pixels=cfg.vision_max_pixels)
 
     config = AutoConfig.from_pretrained(cfg.model_name)
+
+    maybe_apply_liger_kernel(cfg)
 
     attn_impl = os.environ.get("OCELOT_ATTN_IMPLEMENTATION", "flash_attention_2").strip() or "flash_attention_2"
     load_4bit = os.environ.get("OCELOT_LOAD_IN_4BIT", "1").strip().lower() in {"1", "true", "yes"}

--- a/src/training/modeling/factory.py
+++ b/src/training/modeling/factory.py
@@ -21,11 +21,25 @@ class ModelBundle:
     callbacks: list[object]
 
 
+def _local_rank() -> int:
+    try:
+        return int(os.environ.get("LOCAL_RANK", "0"))
+    except Exception:
+        return 0
+
+
 def build_model_and_processor(cfg: RunConfig) -> ModelBundle:
     patch_torch_linspace_steps()
 
     os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
     os.environ.setdefault("PYTORCH_ALLOC_CONF", "expandable_segments:True")
+
+    local_rank = _local_rank()
+    use_cuda = torch.cuda.is_available()
+    if use_cuda:
+        torch.cuda.set_device(local_rank)
+    # Pin each distributed rank to its own GPU during from_pretrained (default cuda:0 otherwise).
+    load_device_map = {"": local_rank} if use_cuda else None
 
     processor = AutoProcessor.from_pretrained(cfg.model_name)
     configure_qwen_processor_image_limits(processor, vision_max_pixels=cfg.vision_max_pixels)
@@ -48,7 +62,7 @@ def build_model_and_processor(cfg: RunConfig) -> ModelBundle:
             torch_dtype=torch.bfloat16,
             quantization_config=bnb_config,
             attn_implementation=attn_impl,
-            device_map=None,
+            device_map=load_device_map,
             config=config,
         )
         model = prepare_model_for_kbit_training(model)
@@ -57,7 +71,7 @@ def build_model_and_processor(cfg: RunConfig) -> ModelBundle:
             cfg.model_name,
             torch_dtype=torch.bfloat16,
             attn_implementation=attn_impl,
-            device_map=None,
+            device_map=load_device_map,
             config=config,
         )
     
@@ -137,12 +151,7 @@ def build_model_and_processor(cfg: RunConfig) -> ModelBundle:
     # Ensure model is on an accelerator before Trainer init (mirrors script).
     if os.environ.get("MOVE_MODEL_TO_CUDA_BEFORE_TRAINER", "1").strip().lower() in {"1", "true", "yes"}:
         if torch.cuda.is_available():
-            try:
-                local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-            except Exception:
-                local_rank = 0
-            device = torch.device(f"cuda:{local_rank}")
-            model.to(device)
+            model.to(torch.device(f"cuda:{local_rank}"))
         elif getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
             model.to("mps")
 

--- a/src/training/modeling/liger_kernels.py
+++ b/src/training/modeling/liger_kernels.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+
+import torch
+
+from core.config import RunConfig
+
+
+def _truthy_env(name: str, default: str = "0") -> bool:
+    return os.environ.get(name, default).strip().lower() in {"1", "true", "yes"}
+
+
+def liger_fused_ce_active(cfg: RunConfig | None = None) -> bool:
+    """
+    True when Liger fused linear cross-entropy is patched in (``use_liger`` without ``liger_cross_entropy``).
+
+    In this mode SFT must not pass ``logits_to_keep``: Liger slices hidden states internally and its
+    fused loss calls ``.view()`` on a non-contiguous slice, which raises at runtime. Fused LCE already
+    avoids materializing full-vocab logits, so ``logits_to_keep`` is redundant for SFT anyway.
+
+    When ``cfg`` is omitted, reads ``OCELOT_USE_LIGER`` / ``OCELOT_LIGER_CROSS_ENTROPY``.
+    """
+    if cfg is not None:
+        return cfg.use_liger and not cfg.liger_cross_entropy
+    return _truthy_env("OCELOT_USE_LIGER", "0") and not _truthy_env("OCELOT_LIGER_CROSS_ENTROPY", "0")
+
+
+def liger_model_kind(model_name: str) -> str | None:
+    """Return 'qwen3_vl_moe', 'qwen3_vl', or None if Liger has no patch for this checkpoint."""
+    name = model_name.lower()
+    if "qwen3-vl-moe" in name or "qwen3_vl_moe" in name:
+        return "qwen3_vl_moe"
+    if "qwen3-vl" in name or "qwen3_vl" in name:
+        return "qwen3_vl"
+    return None
+
+
+def maybe_apply_liger_kernel(cfg: RunConfig) -> None:
+    """
+    Patch Qwen3-VL modeling with Liger fused kernels before ``from_pretrained``.
+
+    Controlled by ``RunConfig.use_liger`` (CLI ``--use-liger``, env ``OCELOT_USE_LIGER``).
+    Defaults to fused linear CE; set ``liger_cross_entropy`` / ``OCELOT_LIGER_CROSS_ENTROPY=1`` for
+    ``cross_entropy=True`` instead (mutually exclusive with fused linear CE).
+    """
+    if not cfg.use_liger:
+        return
+    if not torch.cuda.is_available():
+        if os.environ.get("LOCAL_RANK", "0") == "0":
+            print("[model] use_liger=True but CUDA unavailable; skipping Liger kernels", flush=True)
+        return
+
+    kind = liger_model_kind(cfg.model_name)
+    if kind is None:
+        if os.environ.get("LOCAL_RANK", "0") == "0":
+            print(f"[model] use_liger=True but no Liger patch for {cfg.model_name!r}; skipping", flush=True)
+        return
+
+    use_cross_entropy = cfg.liger_cross_entropy
+    fused_linear_cross_entropy = not use_cross_entropy
+
+    if kind == "qwen3_vl_moe":
+        from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl_moe
+
+        apply_liger_kernel_to_qwen3_vl_moe(
+            cross_entropy=use_cross_entropy,
+            fused_linear_cross_entropy=fused_linear_cross_entropy,
+        )
+    else:
+        from liger_kernel.transformers import apply_liger_kernel_to_qwen3_vl
+
+        apply_liger_kernel_to_qwen3_vl(
+            cross_entropy=use_cross_entropy,
+            fused_linear_cross_entropy=fused_linear_cross_entropy,
+        )
+
+    if os.environ.get("LOCAL_RANK", "0") == "0":
+        mode = "cross_entropy" if use_cross_entropy else "fused_linear_cross_entropy"
+        print(f"[model] applied Liger kernels ({kind}, {mode})", flush=True)

--- a/src/training/modeling/liger_kernels.py
+++ b/src/training/modeling/liger_kernels.py
@@ -11,6 +11,13 @@ def _truthy_env(name: str, default: str = "0") -> bool:
     return os.environ.get(name, default).strip().lower() in {"1", "true", "yes"}
 
 
+def use_liger_active(cfg: RunConfig | None = None) -> bool:
+    """True when Liger kernel patching is enabled (``use_liger`` or ``OCELOT_USE_LIGER``)."""
+    if cfg is not None:
+        return cfg.use_liger
+    return _truthy_env("OCELOT_USE_LIGER", "0")
+
+
 def liger_fused_ce_active(cfg: RunConfig | None = None) -> bool:
     """
     True when Liger fused linear cross-entropy is patched in (``use_liger`` without ``liger_cross_entropy``).
@@ -23,7 +30,7 @@ def liger_fused_ce_active(cfg: RunConfig | None = None) -> bool:
     """
     if cfg is not None:
         return cfg.use_liger and not cfg.liger_cross_entropy
-    return _truthy_env("OCELOT_USE_LIGER", "0") and not _truthy_env("OCELOT_LIGER_CROSS_ENTROPY", "0")
+    return use_liger_active() and not _truthy_env("OCELOT_LIGER_CROSS_ENTROPY", "0")
 
 
 def liger_model_kind(model_name: str) -> str | None:

--- a/src/training/requirements-linux-cuda.txt
+++ b/src/training/requirements-linux-cuda.txt
@@ -37,6 +37,7 @@ jedi==0.19.2
 Jinja2==3.1.6
 jupyter_client==8.7.0
 jupyter_core==5.9.1
+liger-kernel==0.8.0
 MarkupSafe==3.0.3
 matplotlib-inline==0.2.1
 mergekit==0.1.4
@@ -104,7 +105,7 @@ trl==0.26.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
-urllib3==2.7.0
+urllib3==2.6.3
 wcwidth==0.2.14
 weave==0.52.36
 wheel==0.46.2

--- a/src/training/requirements-linux-cuda.txt
+++ b/src/training/requirements-linux-cuda.txt
@@ -105,7 +105,7 @@ trl==0.26.1
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 tzdata==2025.3
-urllib3==2.6.3
+urllib3==2.7.0
 wcwidth==0.2.14
 weave==0.52.36
 wheel==0.46.2

--- a/test/training/test_ipo_vision_concat.py
+++ b/test/training/test_ipo_vision_concat.py
@@ -1,0 +1,35 @@
+import torch
+
+from methods.trl_vision_safe import concatenated_vision_kwargs
+
+
+def _patch_count(grid: torch.Tensor) -> int:
+    return int(grid.prod(-1).sum().item())
+
+
+def test_concatenated_vision_dup_two_images_single_example():
+    """Regression: batch_size=1 with two images must duplicate both pv and grid."""
+    patches_per_image = 1024
+    pv = torch.randn(patches_per_image * 2, 64)
+    grid = torch.tensor([[1, 32, 32], [1, 32, 32]], dtype=torch.int64)
+    batch = {"prompt_pixel_values": pv, "prompt_image_grid_thw": grid}
+
+    kwargs = concatenated_vision_kwargs(batch)
+
+    assert kwargs["pixel_values"].shape[0] == pv.shape[0] * 2
+    assert kwargs["image_grid_thw"].shape[0] == grid.shape[0] * 2
+    assert _patch_count(kwargs["image_grid_thw"]) == kwargs["pixel_values"].shape[0]
+
+
+def test_concatenated_vision_dup_keeps_grid_and_patches_aligned():
+    micro_batch = 2
+    pv = torch.randn(2048, 64)
+    grid = torch.tensor([[1, 32, 32], [1, 32, 32]], dtype=torch.int64)
+    batch = {"prompt_pixel_values": pv, "prompt_image_grid_thw": grid}
+
+    kwargs = concatenated_vision_kwargs(batch)
+
+    assert kwargs["pixel_values"].shape[0] == pv.shape[0] * 2
+    assert kwargs["image_grid_thw"].shape[0] == grid.shape[0] * 2
+    assert _patch_count(kwargs["image_grid_thw"]) == kwargs["pixel_values"].shape[0]
+    assert micro_batch == 2  # documents expected batch layout for this fixture

--- a/test/training/test_liger_factory.py
+++ b/test/training/test_liger_factory.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_TRAINING = Path(__file__).resolve().parents[2] / "src" / "training"
+if str(_TRAINING) not in sys.path:
+    sys.path.insert(0, str(_TRAINING))
+
+from core.config import RunConfig
+from modeling.liger_kernels import liger_fused_ce_active, liger_model_kind
+
+
+def test_liger_model_kind_qwen3_vl() -> None:
+    assert liger_model_kind("Qwen/Qwen3-VL-4B-Instruct") == "qwen3_vl"
+
+
+def test_liger_model_kind_qwen3_vl_moe() -> None:
+    assert liger_model_kind("Qwen/Qwen3-VL-MoE-30B-A3B-Instruct") == "qwen3_vl_moe"
+
+
+def test_liger_model_kind_unsupported() -> None:
+    assert liger_model_kind("Qwen/Qwen2-VL-2B-Instruct") is None
+
+
+def test_liger_fused_ce_active_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OCELOT_USE_LIGER", raising=False)
+    monkeypatch.delenv("OCELOT_LIGER_CROSS_ENTROPY", raising=False)
+    assert liger_fused_ce_active() is False
+
+    monkeypatch.setenv("OCELOT_USE_LIGER", "1")
+    assert liger_fused_ce_active() is True
+
+    monkeypatch.setenv("OCELOT_LIGER_CROSS_ENTROPY", "1")
+    assert liger_fused_ce_active() is False
+
+
+def test_liger_fused_ce_active_from_run_config() -> None:
+    cfg = RunConfig(
+        trainer="sft",
+        epochs=1,
+        model_name="Qwen/Qwen3-VL-4B-Instruct",
+        data_path="",
+        output_dir=".",
+        resume_from=None,
+        deepspeed=None,
+        prepared_data_dir=None,
+        sft_max_length=1024,
+        sft_max_prompt_length=512,
+        tokenize_batch_size=1,
+        store_vision_dtype="float16",
+        vision_max_pixels=None,
+        lora_rank=8,
+        sft_warmup_epochs=0,
+        sft_learning_rate=3e-5,
+        pref_learning_rate=5e-6,
+        ipo_beta=0.1,
+        dpo_beta=0.1,
+    )
+    assert liger_fused_ce_active(cfg) is False
+
+    cfg_on = RunConfig(**{**cfg.__dict__, "use_liger": True})
+    assert liger_fused_ce_active(cfg_on) is True
+
+    cfg_ce = RunConfig(**{**cfg.__dict__, "use_liger": True, "liger_cross_entropy": True})
+    assert liger_fused_ce_active(cfg_ce) is False
+
+
+def test_run_config_use_liger_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OCELOT_USE_LIGER", "1")
+    monkeypatch.setenv("OCELOT_LIGER_CROSS_ENTROPY", "0")
+    cfg = RunConfig.from_argv(["--trainer", "sft", "--epochs", "1", "--data-path", "/tmp/data.json"])
+    assert cfg.use_liger is True
+    assert cfg.liger_cross_entropy is False
+
+
+def test_run_config_use_liger_cli_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OCELOT_USE_LIGER", "1")
+    cfg = RunConfig.from_argv(
+        ["--trainer", "sft", "--epochs", "1", "--data-path", "/tmp/data.json", "--no-use-liger"]
+    )
+    assert cfg.use_liger is False

--- a/test/training/test_liger_factory.py
+++ b/test/training/test_liger_factory.py
@@ -10,7 +10,7 @@ if str(_TRAINING) not in sys.path:
     sys.path.insert(0, str(_TRAINING))
 
 from core.config import RunConfig
-from modeling.liger_kernels import liger_fused_ce_active, liger_model_kind
+from modeling.liger_kernels import liger_fused_ce_active, liger_model_kind, use_liger_active
 
 
 def test_liger_model_kind_qwen3_vl() -> None:
@@ -23,6 +23,13 @@ def test_liger_model_kind_qwen3_vl_moe() -> None:
 
 def test_liger_model_kind_unsupported() -> None:
     assert liger_model_kind("Qwen/Qwen2-VL-2B-Instruct") is None
+
+
+def test_use_liger_active_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OCELOT_USE_LIGER", raising=False)
+    assert use_liger_active() is False
+    monkeypatch.setenv("OCELOT_USE_LIGER", "1")
+    assert use_liger_active() is True
 
 
 def test_liger_fused_ce_active_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/test/training/test_logits_to_keep.py
+++ b/test/training/test_logits_to_keep.py
@@ -14,6 +14,7 @@ if str(_TRAINING) not in sys.path:
 from methods.logits_to_keep import (
     align_logits_to_labels,
     compute_logits_to_keep_from_labels,
+    model_supports_logits_to_keep,
     slice_labels_for_logits_to_keep,
 )
 
@@ -38,3 +39,24 @@ def test_align_logits_to_labels_trims_prefix() -> None:
     labels = torch.zeros(1, 6, dtype=torch.long)
     aligned = align_logits_to_labels(logits, labels)
     assert aligned.shape == (1, 6, 4)
+
+
+class _InnerWithLogitsToKeep:
+    def _supports_logits_to_keep(self) -> bool:
+        return True
+
+    def forward(self, input_ids, logits_to_keep=None):
+        return input_ids
+
+
+class _DeepSpeedLikeWrapper:
+    def __init__(self, module):
+        self.module = module
+
+    def forward(self, *args, **kwargs):
+        return self.module(*args, **kwargs)
+
+
+def test_model_supports_logits_to_keep_unwraps_deepspeed_module() -> None:
+    inner = _InnerWithLogitsToKeep()
+    assert model_supports_logits_to_keep(_DeepSpeedLikeWrapper(inner))

--- a/test/training/test_logits_to_keep.py
+++ b/test/training/test_logits_to_keep.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+
+_TRAINING = Path(__file__).resolve().parents[2] / "src" / "training"
+if str(_TRAINING) not in sys.path:
+    sys.path.insert(0, str(_TRAINING))
+
+from methods.logits_to_keep import (
+    align_logits_to_labels,
+    compute_logits_to_keep_from_labels,
+    slice_labels_for_logits_to_keep,
+)
+
+
+def test_compute_logits_to_keep_from_labels_prompt_masked() -> None:
+    labels = torch.tensor([[-100, -100, -100, 10, 11, 12]])
+    assert compute_logits_to_keep_from_labels(labels) == 4
+
+
+def test_compute_logits_to_keep_all_ignored() -> None:
+    labels = torch.full((2, 8), -100)
+    assert compute_logits_to_keep_from_labels(labels) is None
+
+
+def test_slice_labels_for_logits_to_keep() -> None:
+    labels = torch.tensor([[1, 2, 3, 4, 5]])
+    assert slice_labels_for_logits_to_keep(labels, 2).tolist() == [[4, 5]]
+
+
+def test_align_logits_to_labels_trims_prefix() -> None:
+    logits = torch.zeros(1, 10, 4)
+    labels = torch.zeros(1, 6, dtype=torch.long)
+    aligned = align_logits_to_labels(logits, labels)
+    assert aligned.shape == (1, 6, 4)

--- a/test/training/test_tokenized_validation.py
+++ b/test/training/test_tokenized_validation.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from datasets import Dataset
+
+from data.pipeline import (
+    _drop_image_samples,
+    _filter_tokenized_valid_batch,
+    _filter_valid_tokenized_rows,
+    _has_image_flags,
+    _tokenized_row_is_valid,
+    _validation_input_columns,
+)
+
+
+def _row(*, bad: bool = False) -> dict:
+    seq_len = 8
+    ids = list(range(seq_len))
+    row = {
+        "input_ids": ids,
+        "attention_mask": [1] * seq_len,
+        "labels": [-100] * seq_len,
+        "mm_token_type_ids": [0] * seq_len,
+        "prompt_input_ids": ids[:4],
+        "prompt_attention_mask": [1] * 4,
+        "prompt_mm_token_type_ids": [0] * 4,
+        "chosen_input_ids": ids,
+        "chosen_attention_mask": [1] * seq_len,
+        "chosen_mm_token_type_ids": [0] * seq_len,
+        "rejected_input_ids": ids,
+        "rejected_attention_mask": [1] * seq_len,
+        "rejected_mm_token_type_ids": [0] * seq_len,
+        "image_grid_thw": [[1, 1, 2]],
+        "pixel_values_shape": [2, 4],
+        "pixel_values_bytes": np.zeros((2, 4), dtype=np.float16).tobytes(),
+        "chosen": "ok",
+        "rejected": "no",
+    }
+    if bad:
+        row["attention_mask"] = [1] * (seq_len - 1)
+    return row
+
+
+def test_validation_input_columns_excludes_heavy_fields() -> None:
+    ds = Dataset.from_list([_row()])
+    cols = _validation_input_columns(ds)
+    assert "pixel_values_bytes" not in cols
+    assert "chosen" not in cols
+    assert "pixel_values_shape" in cols
+
+
+def test_filter_tokenized_valid_batch() -> None:
+    batch = Dataset.from_list([_row(), _row(bad=True)]).to_dict()
+    keep = _filter_tokenized_valid_batch(batch)
+    assert keep == [True, False]
+
+
+def test_filter_valid_tokenized_rows_drops_bad_rows() -> None:
+    ds = Dataset.from_list([_row(), _row(bad=True), _row()])
+    filtered, dropped = _filter_valid_tokenized_rows(ds, desc="test")
+    assert dropped == 1
+    assert len(filtered) == 2
+    assert all(_tokenized_row_is_valid(ex) for ex in filtered)
+
+
+def test_filter_valid_tokenized_rows_can_skip() -> None:
+    ds = Dataset.from_list([_row(), _row(bad=True)])
+    filtered, dropped = _filter_valid_tokenized_rows(ds, desc="test", skip=True)
+    assert dropped == 0
+    assert len(filtered) == 2
+
+
+def test_drop_image_samples_uses_lightweight_columns_only() -> None:
+    heavy = b"x" * (1024 * 1024)
+    ds = Dataset.from_list(
+        [
+            {**_row(), "pixel_values_bytes": heavy, "image_grid_thw": [[1, 1, 2]]},
+            {**_row(), "pixel_values_bytes": heavy, "image_grid_thw": []},
+        ]
+    )
+    flags = _has_image_flags(ds)
+    assert flags == [True, False]
+    filtered, n_img, dropped = _drop_image_samples(ds, drop_ratio=1.0, seed=0)
+    assert n_img == 1
+    assert dropped == 1
+    assert len(filtered) == 1
+    assert filtered[0]["image_grid_thw"] == []


### PR DESCRIPTION
Summary
Adds optional Liger fused kernels for Qwen3-VL training on CUDA, plus logits_to_keep optimizations for SFT and IPO when Liger is off.

Liger (liger-kernel)

Patches Qwen3-VL / Qwen3-VL-MoE before from_pretrained (fused linear cross-entropy by default; optional cross_entropy mode).
Enabled via RunConfig (--use-liger, --liger-cross-entropy) or env (OCELOT_USE_LIGER, OCELOT_LIGER_CROSS_ENTROPY).
Skips automatically on non-CUDA or unsupported model names.
Adds liger-kernel to the Linux CUDA requirements.

logits_to_keep

Shared helpers compute how many trailing positions need LM-head logits from label masks.
SFT and IPO pass logits_to_keep into the forward pass when the model supports it (USE_LOGITS_TO_KEEP, default on), reducing memory on long sequences.
Disabled automatically when Liger fused linear CE is active (incompatible and redundant).